### PR TITLE
[codex] Unify rounded corners with shared radius token

### DIFF
--- a/_pages/Home/Home.tsx
+++ b/_pages/Home/Home.tsx
@@ -170,7 +170,7 @@ export default function Home({
           >
             <MotionedLink
               href="/projects"
-              className="inline-flex items-center justify-center px-4 sm:px-5 md:px-6 py-2 sm:py-2.5 md:py-3 rounded-full bg-gradient-to-r from-red-700 to-purple-900 text-white font-medium hover:opacity-90 transition-opacity text-xs sm:text-sm md:text-base"
+              className="inline-flex items-center justify-center px-4 sm:px-5 md:px-6 py-2 sm:py-2.5 md:py-3 rounded-lg bg-gradient-to-r from-red-700 to-purple-900 text-white font-medium hover:opacity-90 transition-opacity text-xs sm:text-sm md:text-base"
             >
               {projectsLinkText}
             </MotionedLink>

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,7 +96,7 @@ div[data-overlay-container="true"]{
     font-weight: 700;
     padding: 0.5rem 1rem;
     border: 0;
-    border-radius: .5rem;
+    border-radius: var(--radius);
     z-index: 1;
 }
 .button.dark{

--- a/features/Home/Home.tsx
+++ b/features/Home/Home.tsx
@@ -89,7 +89,7 @@ export default function Home({
           <div className="pointer-events-auto flex justify-center lg:justify-start">
             <Link
               href="/projects"
-              className="inline-flex items-center justify-center px-4 sm:px-5 md:px-6 py-2 sm:py-2.5 md:py-3 rounded-full bg-gradient-to-r from-red-700 to-purple-900 text-white font-medium hover:opacity-90 transition-opacity text-xs sm:text-sm md:text-base"
+              className="inline-flex items-center justify-center px-4 sm:px-5 md:px-6 py-2 sm:py-2.5 md:py-3 rounded-lg bg-gradient-to-r from-red-700 to-purple-900 text-white font-medium hover:opacity-90 transition-opacity text-xs sm:text-sm md:text-base"
             >
               {projectsLinkText}
             </Link>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -91,9 +91,10 @@ module.exports = {
         },
       },
       borderRadius: {
+        DEFAULT: "var(--radius)",
         lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
+        md: "var(--radius)",
+        sm: "var(--radius)",
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- Route normal Tailwind rounded sizes through the shared `--radius` token.
- Update the home CTA from `rounded-full` to the shared panel radius.
- Replace the remaining raw `.button` border radius with `var(--radius)`.

## Validation
- `npm run build`